### PR TITLE
Trimmed version, default passwords don't have hypens or bad language

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Spectrum Router Default Password Wordlist
 
 This word list combines thousands of adjectives with thousands of nouns for a total of 11,215,122 combined words. With hashcat you can add in every combination of 3 digits after each combined word with ?d?d?d
 
+The trimmed version removes any words with hypens and also naughty words, which should/would not be included in default Spectrum router passwords.
+
 The final hashcat command would look something like this:
 
 hashcat -m 22000 -a 6 wifihash.txt SpectrumSniper.txt ?d?d?d 


### PR DESCRIPTION
Includes trimmed.SpectrumSniper.7z which trims the original SpectrumSniper.7z to remove any words with hyphens and/or naughty language, that would not be used in Spectrum router default passwords, reducing the total line count by about ~435,000 from the original.